### PR TITLE
Make escaping data keys parsed from e.g. CSV a bit friendlier. Change…

### DIFF
--- a/test/py/test_pipeline.py
+++ b/test/py/test_pipeline.py
@@ -48,10 +48,13 @@ def test_basics_1(testresourcepath, expected_modout1):
                             fprint=[
                                 (BF_NS('name'), follow(SCH_NS('title'))),
                                 (BF_NS('creator'), follow(SCH_NS('author'))),
+                                (BF_NS('language'), var('lang')),
                             ], attach=False # Can remove when we have smart sssions to avoid duplicate instantiates links
                         ),
                     )
-                ]
+                ],
+                # Not really necessary; just testing vars in this scenario
+                vars={'lang': follow(SCH_NS('inLanguage'))}
             )
         )
     }
@@ -65,13 +68,11 @@ def test_basics_1(testresourcepath, expected_modout1):
         # Rule only for output resource type of Work
         (SCH_NS('author'), WT): materialize(BF_NS('Person'),
                                     BF_NS('creator'),
-                                    vars=[
-                                        ('name', target()),
-                                        ('birthDate', follow(SCH_NS('authorBirthDate'),
-                                            origin=var('input-resource')
-                                            )
-                                        ),
-                                    ],
+                                    vars={
+                                        'name': target(),
+                                        'birthDate': follow(SCH_NS('authorBirthDate'),
+                                            origin=var('input-resource'))
+                                    },
                                     fprint=[
                                         (BF_NS('name'), var('name')),
                                         (BF_NS('birthDate'), var('birthDate')),
@@ -98,7 +99,7 @@ def test_basics_1(testresourcepath, expected_modout1):
     assert len(list(util.all_origins(modout, only_types={BF_NS('Instance')}))) == 1
     assert len(list(util.all_origins(modout, only_types={BF_NS('Work')}))) == 1
     assert len(list(util.all_origins(modout, only_types={BF_NS('Person')}))) == 1
-
+    assert len(list(modout.match(None, BF_NS('birthDate'), '1919-01-01'))) == 1
 
 
 if __name__ == '__main__':

--- a/tools/py/pipeline/link_materialize_actions.py
+++ b/tools/py/pipeline/link_materialize_actions.py
@@ -163,7 +163,7 @@ def materialize(typ, rel=None, origin=None, unique=None, fprint=None, links=None
         attach_ = False if rel is None and r is None else attach
 
         # Set up variables to be made available in any derived contexts
-        for k, v in (vars or []):
+        for k, v in (vars or {}).items():
             if None in (k, v): continue
             #v = v if isinstance(v, list) else [v]
             v = v(ctx) if is_pipeline_action(v) else v

--- a/tools/py/pipeline/main.py
+++ b/tools/py/pipeline/main.py
@@ -144,10 +144,11 @@ def materialize_entity(ctx, etype, fprint=None):
     fprint - list of key/value tuples of data to use in generating
                 unique ID, or None in which case one is randomly generated
     '''
+    fprint_processed = []
     for ix, (k, v) in enumerate(fprint):
-        if is_pipeline_action(v):
-            fprint[ix] = v(ctx)
-    return I(resource_id(etype, fprint=fprint, idgen=ctx.idgen, vocabbase=ctx.base))
+        fprint_processed.append((k, v(ctx) if is_pipeline_action(v) else v))
+    return I(resource_id(etype, fprint=fprint_processed, idgen=ctx.idgen,
+                vocabbase=ctx.base))
 
 
 def create_resource(output_model, rtypes, fprint, links, existing_ids=None, id_helper=None, preserve_fprint=False):

--- a/tools/py/serial/csv.py
+++ b/tools/py/serial/csv.py
@@ -70,6 +70,8 @@ def parse_iter(csvfp, template_obj, model_fact=newmodel,
         if first_proper_row:
             adapted_keys = {}
             for k in row.keys():
+                # URI escape, but treat spaces as special case, for convenience
+                adapted = iri.percent_encode(k.replace(' ', '_'))
                 adapted = iri.percent_encode(k)
                 #adapted = OMIT_FROM_SLUG_PAT.sub('_', k)
                 # Ensure there are no clashes after escaping

--- a/tools/py/serial/simpleobj.py
+++ b/tools/py/serial/simpleobj.py
@@ -64,7 +64,8 @@ def parse_iter(csvfp, template_obj, model_fact=newmodel,
         if first_proper_row:
             adapted_keys = {}
             for k in row.keys():
-                adapted = iri.percent_encode(k)
+                # URI escape, but treat spaces as special case, for convenience
+                adapted = iri.percent_encode(k.replace(' ', '_'))
                 #adapted = OMIT_FROM_SLUG_PAT.sub('_', k)
                 # Ensure there are no clashes after escaping
                 while adapted in adapted_keys:


### PR DESCRIPTION
… materialize/vars to dict, from list