### PR TITLE
Pipeline/materialize fix + vlit parse fix

### DIFF
--- a/tools/py/pipeline/main.py
+++ b/tools/py/pipeline/main.py
@@ -18,9 +18,8 @@ using patterns and declared rules.
 
 import json
 import itertools
-import functools
+# import functools
 from operator import itemgetter
-import logging
 # from enum import Enum #https://docs.python.org/3.4/library/enum.html
 from collections import defaultdict, OrderedDict
 from types import GeneratorType
@@ -122,7 +121,8 @@ def resource_id(etype, fprint=None, idgen=default_idgen(None), vocabbase=None):
         fprint_processed.append((k, v))
 
     if fprint_processed:
-        fprint_processed.append((VTYPE_REL, etype))
+        if (VTYPE_REL, etype) not in fprint_processed:
+            fprint_processed.append((VTYPE_REL, etype))
         fprint_processed.sort()
         plaintext = json.dumps(fprint_processed, separators=(',', ':'), cls=OrderedJsonEncoder)
         eid = idgen.send(plaintext)

--- a/tools/py/serial/literate_pure_helper.py
+++ b/tools/py/serial/literate_pure_helper.py
@@ -113,7 +113,7 @@ explicit_iriref = Combine(Suppress("<") + IRIREF + Suppress(">")) \
 
 value_expr      = Combine(explicit_iriref | QUOTED_STRING | rest_of_line).leaveWhitespace()
 prop            = Optional(White(' \t').leaveWhitespace(), '') + Suppress('*' + White()) + IDENT_KEY + Suppress(':') + Optional(value_expr, None)
-propset         = Group(delimited_list(prop, delim='\n'))
+propset         = Group(delimited_list(prop | COMMENT, delim='\n'))
 resource_header = Word('#') + Optional(IRIREF, None) + Optional(QuotedString('[', end_quote_char=']'), None)
 resource_block  = Forward()
 resource_block  << Group(resource_header + White('\n').suppress() + Suppress(ZeroOrMore(blank_line)) + propset)
@@ -223,6 +223,10 @@ def process_resblock(resblock, model, doc):
     outer_indent = -1
     current_outer_prop = None
     for prop in props:
+        if isinstance(prop, str):
+            #Just a comment. Skip.
+            continue
+
         # @iri section is where key IRI prefixes can be set
         # First property encountered determines outer indent
         if outer_indent == -1:


### PR DESCRIPTION
Ensure redundant type info is ignored in pipeline's materialize/fprint. Fix comment parsing for Versa Literate